### PR TITLE
Bug/poker api is straight typed hand validation and more standard payload response

### DIFF
--- a/apps/pokerengine/.github/workflows/maven.yml
+++ b/apps/pokerengine/.github/workflows/maven.yml
@@ -3,8 +3,12 @@ name: Java CI with Maven
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'apps/pokerengine/**'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'apps/pokerengine/**'
 
 jobs:
   build:

--- a/apps/pokerengine/README.md
+++ b/apps/pokerengine/README.md
@@ -2,6 +2,7 @@
 
 A Spring Boot based poker game engine service.
 
+
 ## Prerequisites
 
 - Java 21
@@ -55,11 +56,33 @@ This project uses:
 
 Once the application is running, you can access the API documentation at:
 - Swagger UI: http://localhost:8080/swagger-ui.html
-- OpenAPI Spec: http://localhost:8080/v3/api-docs
+- OpenAPI Spec: http://localhost:8080/api-docs
+
+### API Endpoints
+
+Card model: {"suit": "HEARTS", "value": 2},
+
+#### Check for Straight Hand
+Evaluates if a given set of poker cards forms a straight.
+
+- Endpoint: `POST /api/v1/hand/isstraight`
+- Content-Type: `application/json`
+- Request Body: Array of cards, each with suit and value
+- Response: Boolean indicating if the hand forms a straight
+
+Example Request:
+```json
+{
+  "cards": [
+    {"suit": "HEARTS", "value": 2},
+    {"suit": "CLUBS", "value": 3},
+    {"suit": "DIAMONDS", "value": 4},
+    {"suit": "SPADES", "value": 5},
+    {"suit": "HEARTS", "value": 6}
+  ]
+}
+```
 
 ### API Versioning
-All endpoints are versioned and accessible under `/api/v1/`
-Example endpoints:
-- Health check: http://localhost:8080/api/v1/actuator/health
-- API Documentation: http://localhost:8080/api/v1/api-docs
-- Swagger UI: http://localhost:8080/api/v1/swagger-ui.html
+All endpoints should be versioned , by default they start at v1
+- is straight API: http://localhost:8080/api/v1/hand/isstraight

--- a/apps/pokerengine/pom.xml
+++ b/apps/pokerengine/pom.xml
@@ -71,6 +71,22 @@
             <artifactId>bucket4j-core</artifactId>
             <version>8.7.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
     
     <build>

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/config/PokerConfig.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/config/PokerConfig.java
@@ -1,0 +1,14 @@
+package com.midgard.pokerengine.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "poker")
+public class PokerConfig {
+  private List<Integer> validHandSizes;
+}

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/controller/HandEvaluatorController.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/controller/HandEvaluatorController.java
@@ -1,5 +1,6 @@
 package com.midgard.pokerengine.controller;
 
+import com.midgard.pokerengine.config.PokerConfig;
 import com.midgard.pokerengine.exception.BusinessException;
 import com.midgard.pokerengine.model.HandRequest;
 import com.midgard.pokerengine.service.HandEvaluatorService;
@@ -9,6 +10,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.Operation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Controller for poker hand evaluation endpoints.
@@ -16,17 +26,68 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/hand")
 public class HandEvaluatorController {
-    private final HandEvaluatorService handEvaluatorService;
 
-    public HandEvaluatorController(HandEvaluatorService handEvaluatorService) {
+    private static final Logger logger = LoggerFactory.getLogger(HandEvaluatorController.class);
+
+    private final HandEvaluatorService handEvaluatorService;
+    private final PokerConfig pokerConfig;
+
+    public HandEvaluatorController(HandEvaluatorService handEvaluatorService, PokerConfig pokerConfig) {
         this.handEvaluatorService = handEvaluatorService;
+        this.pokerConfig = pokerConfig;
     }
 
+    @Operation(
+        summary = "Check if cards form a straight",
+        description = "Evaluates whether a given set of cards forms a poker straight. " +
+                    "A straight is five consecutive cards (e.g., 2-3-4-5-6). " +
+                    "Ace can be used as both high (after King) or low (before 2)."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Successfully evaluated the hand",
+            content = @Content(
+                mediaType = "application/json",
+                examples = @ExampleObject(
+                    value = "true",
+                    summary = "Regular straight response"
+                )
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid request (e.g., invalid card values, missing cards)",
+            content = @Content(
+                mediaType = "application/json"
+            )
+        )
+    })
     @PostMapping("/isstraight") 
-    public ResponseEntity<Boolean> evaluateHand(@RequestBody HandRequest request) {
-        if (!request.isValidHandSize()) {
-            throw new BusinessException("Hand must contain exactly 5 or 7 cards", HttpStatus.BAD_REQUEST);
+    public ResponseEntity<Boolean> isStraight(@RequestBody HandRequest handRequest) {
+        logger.info("Received request: {}", handRequest);
+
+        // Validate that the cards list is not null
+        if (handRequest.getCards() == null) {
+            logger.error("Cards list is null");
+            throw new BusinessException("Cards list is null", HttpStatus.BAD_REQUEST);
         }
-        return ResponseEntity.ok(handEvaluatorService.isStraight(request.getCards()));
+
+        // Validate that the hand size is valid
+        if (!pokerConfig.getValidHandSizes().contains(handRequest.getCards().size())) {
+            logger.error("Invalid hand size: {}. Valid sizes are: {}", handRequest.getCards().size(), pokerConfig.getValidHandSizes());
+            String errorMessage = String.format("Invalid hand size: %d. Valid sizes are: %s", handRequest.getCards().size(), pokerConfig.getValidHandSizes());
+            throw new BusinessException(errorMessage, HttpStatus.BAD_REQUEST);
+        }
+
+        // Evaluate if the hand is a straight
+        boolean result = handEvaluatorService.isStraight(handRequest.getCards());
+        return ResponseEntity.ok(result);
+    }
+
+    // Handle invalid input exceptions
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/controller/HandEvaluatorController.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/controller/HandEvaluatorController.java
@@ -4,6 +4,7 @@ import com.midgard.pokerengine.config.PokerConfig;
 import com.midgard.pokerengine.exception.BusinessException;
 import com.midgard.pokerengine.model.HandRequest;
 import com.midgard.pokerengine.service.HandEvaluatorService;
+import com.midgard.pokerengine.model.StandardResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,11 +15,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.time.LocalDateTime;
 
 /**
  * Controller for poker hand evaluation endpoints.
@@ -63,8 +64,8 @@ public class HandEvaluatorController {
             )
         )
     })
-    @PostMapping("/isstraight") 
-    public ResponseEntity<Boolean> isStraight(@RequestBody HandRequest handRequest) {
+    @PostMapping("/isstraight")
+    public ResponseEntity<StandardResponse<Boolean>> isStraight(@RequestBody HandRequest handRequest) {
         logger.info("Received request: {}", handRequest);
 
         // Validate that the cards list is not null
@@ -82,7 +83,16 @@ public class HandEvaluatorController {
 
         // Evaluate if the hand is a straight
         boolean result = handEvaluatorService.isStraight(handRequest.getCards());
-        return ResponseEntity.ok(result);
+
+        // Return a standardized response
+        StandardResponse<Boolean> response = new StandardResponse<>(
+            LocalDateTime.now(),
+            HttpStatus.OK.value(),
+            "Successfully evaluated the hand",
+            result
+        );
+
+        return ResponseEntity.ok(response);
     }
 
     // Handle invalid input exceptions

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/exception/GlobalExceptionHandler.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/exception/GlobalExceptionHandler.java
@@ -1,41 +1,23 @@
 package com.midgard.pokerengine.exception;
 
-import com.midgard.pokerengine.model.error.ApiError;
-import java.time.LocalDateTime;
-import org.springframework.http.HttpStatus;
+import com.midgard.pokerengine.model.StandardResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+import java.time.LocalDateTime;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ApiError> handleBusinessException(
-            BusinessException ex, 
-            WebRequest request) {
-        ApiError apiError = ApiError.builder()
-            .timestamp(LocalDateTime.now())
-            .status(ex.getStatus().value())
-            .error(ex.getStatus().getReasonPhrase())
-            .message(ex.getMessage())
-            .path(request.getDescription(false).replace("uri=", ""))
-            .build();
-        return new ResponseEntity<>(apiError, ex.getStatus());
-    }
-
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiError> handleAllExceptions(
-            Exception ex, 
-            WebRequest request) {
-        ApiError apiError = ApiError.builder()
-            .timestamp(LocalDateTime.now())
-            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-            .error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
-            .message(ex.getMessage())
-            .path(request.getDescription(false).replace("uri=", ""))
-            .build();
-        return new ResponseEntity<>(apiError, HttpStatus.INTERNAL_SERVER_ERROR);
+    public ResponseEntity<StandardResponse<Void>> handleBusinessException(BusinessException ex) {
+        StandardResponse<Void> response = new StandardResponse<>(
+            LocalDateTime.now(),
+            ex.getStatus().value(),
+            ex.getMessage(),
+            null
+        );
+        return ResponseEntity.status(ex.getStatus()).body(response);
     }
 }

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Card.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Card.java
@@ -1,59 +1,20 @@
 package com.midgard.pokerengine.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
 
-/**
- * Represents a playing card with a suit and value.
- * Values range from 2-14 (14 being Ace).
- */
 @Data
-@NoArgsConstructor
+@FieldDefaults(makeFinal = true, level = lombok.AccessLevel.PRIVATE)
+@JsonDeserialize(using = CardDeserializer.class) // Use the custom deserializer
 public class Card {
-  private Suit suit;
-  private int value;
 
-  /**
-   * Creates a new card with the specified suit and value.
-   *
-   * @param suit the card's suit
-   * @param value the card's value (2-14)
-   * @throws IllegalArgumentException if value is invalid
-   */
-  public Card(Suit suit, int value) {
-    if (value < 2 || value > 14) {
-      throw new IllegalArgumentException("Card value must be between 2 and 14");
+    Suit suit;
+    Rank rank;
+
+    // Constructor for manual creation
+    public Card(Suit suit, Rank rank) {
+        this.suit = suit;
+        this.rank = rank;
     }
-    this.suit = suit;
-    this.value = value;
-  }
-
-  /**
-   * Creates a card from a string representation (e.g., "AS" for Ace of Spades).
-   *
-   * @param card the string representation
-   * @return new Card instance
-   * @throws IllegalArgumentException if format is invalid
-   */
-  public static Card fromString(String card) {
-    if (card == null || card.length() != 2) {
-      throw new IllegalArgumentException("Card must be 2 characters");
-    }
-    if (!card.matches("^([2-9]|10|[JQKA])[CDHS]$")) {
-      throw new IllegalArgumentException("Invalid card format: " + card);
-    }
-
-    String rankStr = card.substring(0, card.length() - 1);
-    String suitSymbol = card.substring(card.length() - 1);
-
-    int value = switch (rankStr) {
-      case "J" -> 11;
-      case "Q" -> 12;
-      case "K" -> 13;
-      case "A" -> 14;
-      default -> Integer.parseInt(rankStr);
-    };
-
-    return new Card(Suit.fromSymbol(suitSymbol), value);
-  }
 }

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/CardDeserializer.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/CardDeserializer.java
@@ -1,0 +1,37 @@
+package com.midgard.pokerengine.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class CardDeserializer extends JsonDeserializer<Card> {
+
+    @Override
+    public Card deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        JsonNode node = parser.getCodec().readTree(parser);
+
+        String suitValue = node.get("suit").asText();
+        String rankValue = node.get("rank").asText();
+
+        Suit suit;
+        Rank rank;
+
+        try {
+            suit = Suit.valueOf(suitValue.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid suit: " + suitValue + ". Valid values are: " + Arrays.toString(Suit.values()));
+        }
+
+        try {
+            rank = Rank.valueOf(rankValue.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid rank: " + rankValue + ". Valid values are: " + Arrays.toString(Rank.values()));
+        }
+
+        return new Card(suit, rank);
+    }
+}

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/HandRequest.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/HandRequest.java
@@ -1,25 +1,23 @@
 package com.midgard.pokerengine.model;
 
-import java.util.List;
-
 import lombok.Data;
-import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 /**
  * Request object for poker hand operations.
  * Contains a list of cards that make up a poker hand.
  */
 @Data
-@NoArgsConstructor
 public class HandRequest {
-  private List<Card> cards;
+    private List<Card> cards;
 
-  /**
-   * Validates if the hand size is either 5 or 7 cards.
-   *
-   * @return true if hand size is valid, false otherwise
-   */
-  public boolean isValidHandSize() {
-    return cards != null && (cards.size() == 5 || cards.size() == 7);
-  }
+    // No constructor with PokerConfig; validation will happen elsewhere
+    public HandRequest(List<Card> cards) {
+        this.cards = cards;
+    }
+
+    public HandRequest() {
+        // Default constructor for Jackson
+    }
 }

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Rank.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Rank.java
@@ -1,0 +1,25 @@
+package com.midgard.pokerengine.model;
+
+import java.util.Arrays;
+
+public enum Rank {
+    TWO(2), THREE(3), FOUR(4), FIVE(5), SIX(6), SEVEN(7), EIGHT(8), NINE(9), TEN(10),
+    JACK(11), QUEEN(12), KING(13), ACE(14);
+
+    private final int value;
+
+    Rank(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static Rank fromValue(int value) {
+        return Arrays.stream(values())
+                .filter(rank -> rank.value == value)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid rank value: " + value));
+    }
+}

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/StandardResponse.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/StandardResponse.java
@@ -1,0 +1,15 @@
+package com.midgard.pokerengine.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class StandardResponse<T> {
+    private final LocalDateTime timestamp;
+    private final int status;
+    private final String message;
+    private final T data;
+}

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Suit.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/model/Suit.java
@@ -1,9 +1,11 @@
 package com.midgard.pokerengine.model;
 
+import lombok.Getter;
+
 /**
- * Represents the suit of a playing card.
- * Standard poker suits: Hearts, Diamonds, Clubs, and Spades.
+ * Card suit enum.
  */
+@Getter
 public enum Suit {
   HEARTS("H"),
   DIAMONDS("D"),
@@ -16,22 +18,4 @@ public enum Suit {
     this.symbol = symbol;
   }
 
-  public String getSymbol() {
-    return symbol;
-  }
-
-  /**
-   * Finds a Suit by its symbol representation.
-   *
-   * @param symbol the symbol to look up
-   * @return the matching Suit or null if not found
-   */
-  public static Suit fromSymbol(String symbol) {
-    for (Suit suit : values()) {
-      if (suit.symbol.equals(symbol)) {
-        return suit;
-      }
-    }
-    return null;
-  }
 }

--- a/apps/pokerengine/src/main/java/com/midgard/pokerengine/service/HandEvaluatorService.java
+++ b/apps/pokerengine/src/main/java/com/midgard/pokerengine/service/HandEvaluatorService.java
@@ -1,12 +1,9 @@
 package com.midgard.pokerengine.service;
 
 import com.midgard.pokerengine.model.Card;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 /**
@@ -25,7 +22,7 @@ public class HandEvaluatorService {
     Set<Integer> values = new HashSet<>();
     boolean hasAce = false;
     for (Card card : cards) {
-        int value = card.getValue();
+        int value = card.getRank().getValue();
         if (value == 14) hasAce = true;
         values.add(value);
     }
@@ -45,7 +42,6 @@ public class HandEvaluatorService {
     for (int value : values) {
         cur = Math.min(cur, value);
     }
-    System.out.println("vkk total cards " + Integer.toString(values.size()));
     for(int i = 0; i < values.size() - 1; i++) {
       if(!values.contains(cur + 1)) {
         return false;

--- a/apps/pokerengine/src/main/resources/application.yml
+++ b/apps/pokerengine/src/main/resources/application.yml
@@ -33,3 +33,60 @@ rate-limit:
   capacity: 100
   time-window: 60  # in seconds
   enabled: true
+logging:
+  level:
+    com.midgard.pokerengine: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n"
+poker:
+  valid-hand-sizes: [5, 7]
+  # Can be done, if we want to customize the deck
+  # suits:
+  #   - name: HEARTS
+  #     symbol: H
+  #   - name: DIAMONDS
+  #     symbol: D
+  #   - name: CLUBS
+  #     symbol: C
+  #   - name: SPADES
+  #     symbol: S
+  # ranks:
+  #   - name: TWO
+  #     value: 2
+  #     alternateValues: []
+  #   - name: THREE
+  #     value: 3
+  #     alternateValues: []
+  #   - name: FOUR
+  #     value: 4
+  #     alternateValues: []
+  #   - name: FIVE
+  #     value: 5
+  #     alternateValues: []
+  #   - name: SIX
+  #     value: 6
+  #     alternateValues: []
+  #   - name: SEVEN
+  #     value: 7
+  #     alternateValues: []
+  #   - name: EIGHT
+  #     value: 8
+  #     alternateValues: []
+  #   - name: NINE
+  #     value: 9
+  #     alternateValues: []
+  #   - name: TEN
+  #     value: 10
+  #     alternateValues: []
+  #   - name: JACK
+  #     value: 11
+  #     alternateValues: []
+  #   - name: QUEEN
+  #     value: 12
+  #     alternateValues: []
+  #   - name: KING
+  #     value: 13
+  #     alternateValues: []
+  #   - name: ACE
+  #     value: 14
+  #     alternateValues: [1]

--- a/apps/pokerengine/src/test/java/com/midgard/pokerengine/model/CardTest.java
+++ b/apps/pokerengine/src/test/java/com/midgard/pokerengine/model/CardTest.java
@@ -9,67 +9,53 @@ class CardTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    void fromString_ValidCard_CreatesCard() {
-        Card card = Card.fromString("AS");
-        assertEquals(Suit.SPADES, card.getSuit());
-        assertEquals(14, card.getValue());
-    }
-
-    @Test
-    void fromString_InvalidFormat_ThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> 
-            Card.fromString("1S")
-        );
-    }
-
-    @Test
     void serialize_ValidCard_CreatesValidJson() throws Exception {
-        Card card = new Card(Suit.HEARTS, 10);
+        Card card = new Card(Suit.HEARTS, Rank.TEN);
         String json = objectMapper.writeValueAsString(card);
-        assertEquals("{\"suit\":\"HEARTS\",\"value\":10}", json);
+        assertEquals("{\"suit\":\"HEARTS\",\"rank\":\"TEN\"}", json);
     }
 
     @Test
     void deserialize_ValidJson_CreatesCard() throws Exception {
-        String json = "{\"suit\":\"HEARTS\",\"value\":10}";
+        String json = "{\"suit\":\"HEARTS\",\"rank\":\"TEN\"}";
         Card card = objectMapper.readValue(json, Card.class);
         assertEquals(Suit.HEARTS, card.getSuit());
-        assertEquals(10, card.getValue());
+        assertEquals(Rank.TEN, card.getRank());
     }
 
     @Test
     void equals_SameValues_ReturnsTrue() {
-        Card card1 = new Card(Suit.HEARTS, 10);
-        Card card2 = new Card(Suit.HEARTS, 10);
+        Card card1 = new Card(Suit.HEARTS, Rank.TEN);
+        Card card2 = new Card(Suit.HEARTS, Rank.TEN);
         assertEquals(card1, card2);
         assertEquals(card1.hashCode(), card2.hashCode());
     }
 
     @Test
     void equals_DifferentSuit_ReturnsFalse() {
-        Card card1 = new Card(Suit.HEARTS, 10);
-        Card card2 = new Card(Suit.SPADES, 10);
+        Card card1 = new Card(Suit.HEARTS, Rank.TEN);
+        Card card2 = new Card(Suit.SPADES, Rank.TEN);
         assertNotEquals(card1, card2);
         assertNotEquals(card1.hashCode(), card2.hashCode());
     }
 
     @Test
-    void equals_DifferentValue_ReturnsFalse() {
-        Card card1 = new Card(Suit.HEARTS, 10);
-        Card card2 = new Card(Suit.HEARTS, 11);
+    void equals_DifferentRank_ReturnsFalse() {
+        Card card1 = new Card(Suit.HEARTS, Rank.TEN);
+        Card card2 = new Card(Suit.HEARTS, Rank.JACK);
         assertNotEquals(card1, card2);
         assertNotEquals(card1.hashCode(), card2.hashCode());
     }
 
     @Test
     void equals_Null_ReturnsFalse() {
-        Card card = new Card(Suit.HEARTS, 10);
+        Card card = new Card(Suit.HEARTS, Rank.TEN);
         assertNotEquals(card, null);
     }
 
     @Test
     void equals_DifferentClass_ReturnsFalse() {
-        Card card = new Card(Suit.HEARTS, 10);
+        Card card = new Card(Suit.HEARTS, Rank.TEN);
         assertNotEquals(card, "not a card");
     }
 }

--- a/apps/pokerengine/src/test/java/com/midgard/pokerengine/model/HandRequestTest.java
+++ b/apps/pokerengine/src/test/java/com/midgard/pokerengine/model/HandRequestTest.java
@@ -1,5 +1,7 @@
 package com.midgard.pokerengine.model;
 
+import com.midgard.pokerengine.config.PokerConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -8,121 +10,94 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class HandRequestTest {
 
+
     @Test
-    void isValidHandSize_FiveCards_ReturnsTrue() {
-        HandRequest request = new HandRequest();
-        request.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+    void constructor_FiveCards_ValidHand() {
+        HandRequest request = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         ));
-        assertTrue(request.isValidHandSize());
+        assertNotNull(request);
     }
 
     @Test
-    void isValidHandSize_SevenCards_ReturnsTrue() {
-        HandRequest request = new HandRequest();
-        request.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6),
-            new Card(Suit.CLUBS, 7),
-            new Card(Suit.DIAMONDS, 8)
+    void constructor_SevenCards_ValidHand() {
+        HandRequest request = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX),
+            new Card(Suit.CLUBS, Rank.SEVEN),
+            new Card(Suit.DIAMONDS, Rank.EIGHT)
         ));
-        assertTrue(request.isValidHandSize());
-    }
-
-    @Test
-    void isValidHandSize_SixCards_ReturnsFalse() {
-        HandRequest request = new HandRequest();
-        request.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6),
-            new Card(Suit.CLUBS, 7)
-        ));
-        assertFalse(request.isValidHandSize());
-    }
-
-    @Test
-    void isValidHandSize_NullCards_ReturnsFalse() {
-        HandRequest request = new HandRequest();
-        request.setCards(null);
-        assertFalse(request.isValidHandSize());
+        assertNotNull(request);
     }
 
     @Test
     void equals_SameCards_ReturnsTrue() {
-        HandRequest request1 = new HandRequest();
-        HandRequest request2 = new HandRequest();
         List<Card> cards = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         );
-        request1.setCards(cards);
-        request2.setCards(cards);
-        
+        HandRequest request1 = new HandRequest(cards);
+        HandRequest request2 = new HandRequest(cards);
+
         assertEquals(request1, request2);
         assertEquals(request1.hashCode(), request2.hashCode());
     }
 
     @Test
     void equals_DifferentCards_ReturnsFalse() {
-        HandRequest request1 = new HandRequest();
-        HandRequest request2 = new HandRequest();
-        request1.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+        HandRequest request1 = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         ));
-        request2.setCards(List.of(
-            new Card(Suit.HEARTS, 3),
-            new Card(Suit.CLUBS, 4),
-            new Card(Suit.DIAMONDS, 5),
-            new Card(Suit.SPADES, 6),
-            new Card(Suit.HEARTS, 7)
+
+        HandRequest request2 = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.THREE),
+            new Card(Suit.CLUBS, Rank.FOUR),
+            new Card(Suit.DIAMONDS, Rank.FIVE),
+            new Card(Suit.SPADES, Rank.SIX),
+            new Card(Suit.HEARTS, Rank.SEVEN)
         ));
-        
+
         assertNotEquals(request1, request2);
         assertNotEquals(request1.hashCode(), request2.hashCode());
     }
 
     @Test
     void equals_Null_ReturnsFalse() {
-        HandRequest request = new HandRequest();
-        request.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+        HandRequest request = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         ));
-        
+
         assertNotEquals(request, null);
     }
 
     @Test
     void equals_DifferentClass_ReturnsFalse() {
-        HandRequest request = new HandRequest();
-        request.setCards(List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+        HandRequest request = new HandRequest(List.of(
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         ));
-        
+
         assertNotEquals(request, "not a hand request");
     }
 }

--- a/apps/pokerengine/src/test/java/com/midgard/pokerengine/service/HandEvaluatorServiceTest.java
+++ b/apps/pokerengine/src/test/java/com/midgard/pokerengine/service/HandEvaluatorServiceTest.java
@@ -1,6 +1,7 @@
 package com.midgard.pokerengine.service;
 
 import com.midgard.pokerengine.model.Card;
+import com.midgard.pokerengine.model.Rank;
 import com.midgard.pokerengine.model.Suit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,11 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_RegularStraight_ReturnsTrue() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX)
         );
         assertTrue(handEvaluatorService.isStraight(hand));
     }
@@ -33,11 +34,11 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_AceLowStraight_ReturnsTrue() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 14), // Ace
-            new Card(Suit.CLUBS, 2),
-            new Card(Suit.DIAMONDS, 3),
-            new Card(Suit.SPADES, 4),
-            new Card(Suit.HEARTS, 5)
+            new Card(Suit.HEARTS, Rank.ACE), // Ace as low
+            new Card(Suit.CLUBS, Rank.TWO),
+            new Card(Suit.DIAMONDS, Rank.THREE),
+            new Card(Suit.SPADES, Rank.FOUR),
+            new Card(Suit.HEARTS, Rank.FIVE)
         );
         assertTrue(handEvaluatorService.isStraight(hand));
     }
@@ -45,11 +46,11 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_AceHighStraight_ReturnsTrue() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 10),
-            new Card(Suit.CLUBS, 11),
-            new Card(Suit.DIAMONDS, 12),
-            new Card(Suit.SPADES, 13),
-            new Card(Suit.HEARTS, 14) // Ace
+            new Card(Suit.HEARTS, Rank.TEN),
+            new Card(Suit.CLUBS, Rank.JACK),
+            new Card(Suit.DIAMONDS, Rank.QUEEN),
+            new Card(Suit.SPADES, Rank.KING),
+            new Card(Suit.HEARTS, Rank.ACE) // Ace as high
         );
         assertTrue(handEvaluatorService.isStraight(hand));
     }
@@ -57,11 +58,11 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_NotAStraight_ReturnsFalse() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 6),
-            new Card(Suit.HEARTS, 7)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.SIX),
+            new Card(Suit.HEARTS, Rank.SEVEN)
         );
         assertFalse(handEvaluatorService.isStraight(hand));
     }
@@ -69,13 +70,13 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_SevenCardStraight_ReturnsTrue() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6),
-            new Card(Suit.CLUBS, 7),
-            new Card(Suit.DIAMONDS, 8)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX),
+            new Card(Suit.CLUBS, Rank.SEVEN),
+            new Card(Suit.DIAMONDS, Rank.EIGHT)
         );
         assertTrue(handEvaluatorService.isStraight(hand));
     }
@@ -83,13 +84,13 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_SevenCardWithStraight_ReturnsFalse() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 3),
-            new Card(Suit.DIAMONDS, 4),
-            new Card(Suit.SPADES, 5),
-            new Card(Suit.HEARTS, 6),
-            new Card(Suit.CLUBS, 8),
-            new Card(Suit.DIAMONDS, 10)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.THREE),
+            new Card(Suit.DIAMONDS, Rank.FOUR),
+            new Card(Suit.SPADES, Rank.FIVE),
+            new Card(Suit.HEARTS, Rank.SIX),
+            new Card(Suit.CLUBS, Rank.EIGHT),
+            new Card(Suit.DIAMONDS, Rank.TEN)
         );
         assertFalse(handEvaluatorService.isStraight(hand));
     }
@@ -97,13 +98,13 @@ class HandEvaluatorServiceTest {
     @Test
     void isStraight_SevenCardNoStraight_ReturnsFalse() {
         List<Card> hand = List.of(
-            new Card(Suit.HEARTS, 2),
-            new Card(Suit.CLUBS, 4),
-            new Card(Suit.DIAMONDS, 6),
-            new Card(Suit.SPADES, 8),
-            new Card(Suit.HEARTS, 10),
-            new Card(Suit.CLUBS, 12),
-            new Card(Suit.DIAMONDS, 14)
+            new Card(Suit.HEARTS, Rank.TWO),
+            new Card(Suit.CLUBS, Rank.FOUR),
+            new Card(Suit.DIAMONDS, Rank.SIX),
+            new Card(Suit.SPADES, Rank.EIGHT),
+            new Card(Suit.HEARTS, Rank.TEN),
+            new Card(Suit.CLUBS, Rank.QUEEN),
+            new Card(Suit.DIAMONDS, Rank.ACE)
         );
         assertFalse(handEvaluatorService.isStraight(hand));
     }


### PR DESCRIPTION
## Description
<!-- What does this PR do? -->
- card value better maps to business domain such as TWO, JACK, KING, etc instead of a number 
- Better API response payload for , earlier it just returned true or false
- valid hand sizes can be read from spring config

Cons:
- additional complexity wrt object ser or deserialization
- compile time checks easier to test than run time checks (reading from config vs hard coding)

## Testing
<!-- How was this tested? -->

```
curl -X POST 'http://localhost:8080/api/v1/hand/isstraight' \
-H 'Content-Type: application/json' \
-d '{
  "cards": [
    {"suit": "HEARTS", "rank": "SEVEN"}, {"suit": "HEARTS", "rank": "TWO"},
    {"suit": "HEARTS", "rank": "EIGHT"}, {"suit": "DIAMONDS", "rank": "FOUR"},
    {"suit": "SPADES", "rank": "FIVE"}
  ]
}'
{"timestamp":"2025-04-10T11:22:34.423408","status":200,"message":"Successfully evaluated the hand","data":false}%                                    vishal ~/Documents/git/midgard/apps/pokerengine [bug/poker_api_input_cleaned] $ curl -X POST 'http://localhost:8080/api/v1/hand/isstraight' \
-H 'Content-Type: application/json' \
-d '{
  "cards": [
    {"suit": "HEARTS", "rank": "SIX"}, {"suit": "HEARTS", "rank": "TWO"},
    {"suit": "HEARTS", "rank": "THREE"}, {"suit": "DIAMONDS", "rank": "FOUR"},
    {"suit": "SPADES", "rank": "FIVE"}
  ]
}'
{"timestamp":"2025-04-10T11:23:04.743635","status":200,"message":"Successfully evaluated the hand","data":true}%                                     vishal ~/Documents/git/midgard/apps/pokerengine [bug/poker_api_input_cleaned] $ curl -X POST 'http://localhost:8080/api/v1/hand/isstraight' \
-H 'Content-Type: application/json' \
-d '{
  "cards": [
    {"suit": "HEARTS", "rank": "SIX"}, {"suit": "HEARTS", "rank": "TWO"},
    {"suit": "HEARTS", "rank": "THREE"}, {"suit": "DIAMONDS", "rank": "FOUR"},
    {"suit": "SPADES", "rank": "FIVE"}, {"suit": "DIAMONDS", "rank": "FOUR"}
  ]
}'
{"timestamp":"2025-04-10T11:23:15.149914","status":400,"message":"Invalid hand size: 6. Valid sizes are: [5, 7]","data":null}
```

## Screenshots
<img width="1212" alt="Screenshot 2025-04-10 at 11 33 45 AM" src="https://github.com/user-attachments/assets/a88ec27b-1432-4da2-ac29-8ff0ddf47aca" />

<img width="1134" alt="Screenshot 2025-04-10 at 11 32 06 AM" src="https://github.com/user-attachments/assets/2c347ee2-72a1-44d2-a707-9114a8fcfa79" />
